### PR TITLE
pin dependancy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "url": "http://coolfore.com/"
   },
   "name": "node-red-contrib-dht-sensor",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Node-red node for node-dht-sensor",
   "dependencies": {
-     "node-dht-sensor": "*"
+     "node-dht-sensor": "0.0.6"
   },
   "repository": {
     "type": "git",
@@ -30,30 +30,10 @@
       "rpi-dht22": "dht22-node/dht22-node.js"
     }
   },
-  "_id": "",
-  "_shasum": "",
-  "_from": "",
-  "_npmVersion": "",
-  "_npmUser": {
-  },
-  "_id": "node-red-contrib-dht-sensor@0.0.10",
-  "_shasum": "8b0492c0dcae95970a76bc19642577abb0ac1221",
-  "_from": "node-red-contrib-dht-sensor@",
-  "_npmVersion": "1.4.9",
-  "_npmUser": {
-    "name": "bpmurray",
-    "email": "brendanpmurray@gmail.com"
-  },
   "maintainers": [
     {
       "name": "bpmurray",
       "email": "brendanpmurray@gmail.com"
     }
-  ],
-  "dist": {
-    "shasum": "8b0492c0dcae95970a76bc19642577abb0ac1221",
-    "tarball": "http://registry.npmjs.org/node-red-contrib-dht-sensor/-/node-red-contrib-dht-sensor-0.0.10.tgz"
-  },
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/node-red-contrib-dht-sensor/-/node-red-contrib-dht-sensor-0.0.10.tgz"
+  ]
 }


### PR DESCRIPTION
Hi,

would it be possible to pin the version of node-dht-sensor back to 0.0.6 - so that it will then continue to build on node v0.10.x ? Thanks
