### PR TITLE
Add "isValid" and "errors" attributes in response.

### DIFF
--- a/dht22-node/dht22-node.js
+++ b/dht22-node/dht22-node.js
@@ -83,6 +83,8 @@ module.exports = function(RED) {
 
          msg.payload  = reading.temperature.toFixed(2);
          msg.humidity = reading.humidity.toFixed(2);
+         msg.isValid  = reading.isValid;
+         msg.errors   = reading.errors;
          msg.topic    = node.topic || node.name;
          msg.location = node.name;
          msg.sensorid = 'dht' + node.dht;
@@ -93,7 +95,7 @@ module.exports = function(RED) {
       // respond to inputs....
       this.on('input', function (msg) {
          msg = this.read(msg);
-         
+
          if (msg)
             node.send(msg);
       });


### PR DESCRIPTION
The node-dht-sensor library responds with the number of times an error occurred during reading and whether the result is valid or not.

In this pull request, I added the result to the message.

![image](https://user-images.githubusercontent.com/855724/48523135-8655cb80-e8be-11e8-96a9-0ba186b9de34.png)
